### PR TITLE
Use a strong reference for the contactObject on the contact view model. ...

### DIFF
--- a/MBContactPicker/ContactCollectionViewCellModel.h
+++ b/MBContactPicker/ContactCollectionViewCellModel.h
@@ -10,7 +10,7 @@
 
 @interface ContactCollectionViewCellModel : NSObject
 
-@property (nonatomic, weak) id contactObject;
+@property (nonatomic) id contactObject;
 @property (nonatomic, copy) NSString *contactTitle;
 
 @end


### PR DESCRIPTION
... Makes it easier to use if you don't have a object that is strongly ref'ed to begin with, like a string ID.
