### PR TITLE
[WIP] Refactor CollectionView Datasource/Delegate handling

### DIFF
--- a/MBContactPicker/ContactCollectionView.h
+++ b/MBContactPicker/ContactCollectionView.h
@@ -17,6 +17,7 @@
 
 @optional
 
+- (void)entryTextDidChange:(NSString*)text inContactCollectionView:(ContactCollectionView*)collectionView;
 - (void)didSelectContact:(ContactCollectionViewCellModel*)model inContactCollectionView:(ContactCollectionView*)collectionView;
 - (void)didAddContact:(ContactCollectionViewCellModel*)model toContactCollectionView:(ContactCollectionView*)collectionView;
 - (void)didRemoveContact:(ContactCollectionViewCellModel*)model fromContactCollectionView:(ContactCollectionView*)collectionView;
@@ -27,7 +28,6 @@
 
 @property (nonatomic) NSMutableArray *selectedContacts;
 @property (nonatomic, weak) id<ContactCollectionViewDelegate> contactDelegate;
-@property (nonatomic, weak) id<UITextFieldDelegateImproved> contactEntryTextDelegate;
 
 - (void)addToSelectedContacts:(ContactCollectionViewCellModel*)model withCompletion:(void(^)())completion;
 - (void)removeFromSelectedContacts:(NSInteger)index withCompletion:(void(^)())completion;

--- a/MBContactPicker/MBContactPicker.h
+++ b/MBContactPicker/MBContactPicker.h
@@ -33,7 +33,7 @@
 
 @end
 
-@interface MBContactPicker : UIView <UITextFieldDelegateImproved, UITableViewDataSource, UITableViewDelegate, ContactCollectionViewDelegate>
+@interface MBContactPicker : UIView <UITableViewDataSource, UITableViewDelegate, ContactCollectionViewDelegate>
 
 @property (nonatomic, weak) id<MBContactPickerDelegate> delegate;
 @property (nonatomic, weak) id<MBContactPickerDataSource> datasource;


### PR DESCRIPTION
- [x] Move UICollectionViewDelegate implementation from MBContactPicker to ContactCollectionView
- [x] Move UICollectionViewFlowlayoutDelegate implementation from MBContactPicker to ContactCollectionView
- [x] Move UICollectionViewDataSource implementation from MBContactPicker to ContactCollectionView
- [x] Move UITextFieldDelegate to the collection view as it's just concerned with backspaces, leave UIControlEventEditingChanged delegate intact
- Validate UIResponder behavior after above changes are made (see #21)
- Per @MattCBowman's comment, remove the `entryCell` property and instead use a private `NSString*` property to persist the text that should be in the ContactCollectionViewEntryCell (see #22)
