### PR TITLE
Do not provide completions for contacts which have already been selected...

### DIFF
--- a/MBContactPicker/MBContactPicker.h
+++ b/MBContactPicker/MBContactPicker.h
@@ -45,6 +45,7 @@
 @property (nonatomic, readonly) CGFloat currentContentHeight;
 @property (nonatomic, readonly) CGFloat keyboardHeight;
 @property (nonatomic) CGFloat animationSpeed;
+@property (nonatomic) BOOL allowsCompletionOfSelectedContacts;
 
 - (void)reloadData;
 

--- a/MBContactPicker/MBContactPicker.m
+++ b/MBContactPicker/MBContactPicker.m
@@ -67,6 +67,7 @@ CGFloat const kAnimationSpeed = .25;
     self.originalYOffset = -1;
     self.maxVisibleRows = kMaxVisibleRows;
     self.animationSpeed = kAnimationSpeed;
+    self.allowsCompletionOfSelectedContacts = YES;
     self.translatesAutoresizingMaskIntoConstraints = NO;
     self.clipsToBounds = YES;
     MBContactCollectionView *contactCollectionView = [MBContactCollectionView contactCollectionViewWithFrame:self.bounds];
@@ -266,10 +267,13 @@ CGFloat const kAnimationSpeed = .25;
     {
         [self showSearchTableView];
         NSString *searchString = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"contactTitle contains[cd] %@", searchString];
-        NSMutableArray *selectableContacts = [NSMutableArray arrayWithArray:self.contacts];
-        [selectableContacts removeObjectsInArray:self.contactCollectionView.selectedContacts];
-        self.filteredContacts = [selectableContacts filteredArrayUsingPredicate:predicate];
+        NSPredicate *predicate;
+        if (self.allowsCompletionOfSelectedContacts) {
+            predicate = [NSPredicate predicateWithFormat:@"contactTitle contains[cd] %@", searchString];
+        } else {
+            predicate = [NSPredicate predicateWithFormat:@"contactTitle contains[cd] %@ && !SELF IN %@", searchString, self.contactCollectionView.selectedContacts];
+        }
+        self.filteredContacts = [self.contacts filteredArrayUsingPredicate:predicate];
         [self.searchTableView reloadData];
     }
 }

--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ Thanks to [Roman](http://github.com/firmach) for this enhancement.
 
 ![Orange Colored Contacts](assets/orange-contact.png)
 
+### Suppress completion of alread-selected contacts
+
+By default, the picker shows you contacts which have already been added to the collection as options for completion, but discards them when you choose them, to prevent duplicate contacts in the collection. This is to be consistent with the behavior of Apple's Mail app, but is arguably a deficient user experience. To suppress the already-chosen contacts from the completion list, you can set the following property:
+
+```objc
+self.contactPickerView.allowsCompletionOfSelectedContacts = NO;
+```
+
 ## Motivation
 
 This project exists to because no other cocoapods existed that solved the problem of providing a robust contact selector that was easy to implement, used the latest iOS tools, and matched the appearance of iOS7's flat design.


### PR DESCRIPTION
This change causes the completion list to omit any contacts which have already been selected, providing a more natural user experience, where only relevant choices are present for completion, and you can watch your remaining choices being winnowed down as you work.
