### PR TITLE
Autoresize contact picker when data is reloaded or contacts are added or removed programmatically

### DIFF
--- a/MBContactPicker/MBContactCollectionView.h
+++ b/MBContactPicker/MBContactCollectionView.h
@@ -18,7 +18,7 @@
 
 @optional
 
-- (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView willChangeContentSizeFrom:(CGSize)currentSize to:(CGSize)newSize;
+- (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView willChangeContentSizeTo:(CGSize)newSize;
 - (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView entryTextDidChange:(NSString*)text;
 - (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView didSelectContact:(id<MBContactPickerModelProtocol>)model;
 - (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView didAddContact:(id<MBContactPickerModelProtocol>)model;
@@ -34,6 +34,7 @@
 - (void)addToSelectedContacts:(id<MBContactPickerModelProtocol>)model withCompletion:(void(^)())completion;
 - (void)removeFromSelectedContacts:(NSInteger)index withCompletion:(void(^)())completion;
 - (void)focusOnEntry;
+- (void)scrollToEntryAnimated:(BOOL)animated onComplete:(void(^)())complete;
 - (BOOL)isEntryCell:(NSIndexPath*)indexPath;
 - (BOOL)isPromptCell:(NSIndexPath*)indexPath;
 - (BOOL)isContactCell:(NSIndexPath*)indexPath;

--- a/MBContactPicker/MBContactCollectionView.m
+++ b/MBContactPicker/MBContactCollectionView.m
@@ -344,11 +344,11 @@ typedef NS_ENUM(NSInteger, ContactCollectionViewSection) {
     }
 }
 
-- (void)collectionView:(UICollectionView *)collectionView willChangeContentSizeFrom:(CGSize)currentSize to:(CGSize)newSize
+- (void)collectionView:(UICollectionView *)collectionView willChangeContentSizeTo:(CGSize)newSize
 {
-    if ([self.contactDelegate respondsToSelector:@selector(contactCollectionView:willChangeContentSizeFrom:to:)])
+    if ([self.contactDelegate respondsToSelector:@selector(contactCollectionView:willChangeContentSizeTo:)])
     {
-        [self.contactDelegate contactCollectionView:self willChangeContentSizeFrom:currentSize to:newSize];
+        [self.contactDelegate contactCollectionView:self willChangeContentSizeTo:newSize];
     }
 }
 

--- a/MBContactPicker/MBContactCollectionViewFlowLayout.h
+++ b/MBContactPicker/MBContactCollectionViewFlowLayout.h
@@ -10,7 +10,7 @@
 
 @protocol MBContactCollectionViewDelegateFlowLayout
 
-- (void)collectionView:(UICollectionView*)collectionView willChangeContentSizeFrom:(CGSize)currentSize to:(CGSize)newSize;
+- (void)collectionView:(UICollectionView*)collectionView willChangeContentSizeTo:(CGSize)newSize;
 
 @end
 

--- a/MBContactPicker/MBContactCollectionViewFlowLayout.m
+++ b/MBContactPicker/MBContactCollectionViewFlowLayout.m
@@ -10,8 +10,6 @@
 
 @interface MBContactCollectionViewFlowLayout()
 
-@property (nonatomic) CGSize lastContentSize;
-
 @end
 
 // This is using the answer provided in the stack overflow post: http://bit.ly/INr0ie
@@ -96,21 +94,11 @@
     return YES;
 }
 
-- (void)invalidateLayout
-{
-    self.lastContentSize = self.collectionViewContentSize;
-    
-    [super invalidateLayout];
-}
-
 - (void)finalizeCollectionViewUpdates
 {
-    if (!CGSizeEqualToSize(self.lastContentSize, self.collectionViewContentSize))
+    if ([self.collectionView.delegate respondsToSelector:@selector(collectionView:willChangeContentSizeTo:)])
     {
-        if ([self.collectionView.delegate respondsToSelector:@selector(collectionView:willChangeContentSizeFrom:to:)])
-        {
-            [(id)self.collectionView.delegate collectionView:self.collectionView willChangeContentSizeFrom:self.lastContentSize to:self.collectionViewContentSize];
-        }
+        [(id)self.collectionView.delegate collectionView:self.collectionView willChangeContentSizeTo:self.collectionViewContentSize];
     }
 }
 

--- a/MBContactPicker/MBContactPicker.m
+++ b/MBContactPicker/MBContactPicker.m
@@ -139,6 +139,10 @@ CGFloat const kAnimationSpeed = .25;
     self.contacts = [self.datasource contactModelsForContactPicker:self];
     
     [self.contactCollectionView reloadData];
+    [self.contactCollectionView performBatchUpdates:^{
+    } completion:^(BOOL finished) {
+        [self.contactCollectionView scrollToEntryAnimated:NO onComplete:nil];
+    }];
 }
 
 #pragma mark - Properties
@@ -229,14 +233,17 @@ CGFloat const kAnimationSpeed = .25;
 
 #pragma mark - ContactCollectionViewDelegate
 
-- (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView willChangeContentSizeFrom:(CGSize)currentSize to:(CGSize)newSize
+- (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView willChangeContentSizeTo:(CGSize)newSize
 {
-    self.contactCollectionViewContentSize = newSize;
-    [self updateCollectionViewHeightConstraints];
-
-    if ([self.delegate respondsToSelector:@selector(contactPicker:didUpdateContentHeightTo:)])
+    if (!CGSizeEqualToSize(self.contactCollectionViewContentSize, newSize))
     {
-        [self.delegate contactPicker:self didUpdateContentHeightTo:self.currentContentHeight];
+        self.contactCollectionViewContentSize = newSize;
+        [self updateCollectionViewHeightConstraints];
+        
+        if ([self.delegate respondsToSelector:@selector(contactPicker:didUpdateContentHeightTo:)])
+        {
+            [self.delegate contactPicker:self didUpdateContentHeightTo:self.currentContentHeight];
+        }
     }
 }
 

--- a/Sample/MBContactPicker/Base.lproj/Main.storyboard
+++ b/Sample/MBContactPicker/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13A603" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
     </dependencies>
@@ -78,7 +78,7 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gVn-GW-f9z" customClass="MBContactPicker">
-                                <rect key="frame" x="0.0" y="104" width="320" height="31"/>
+                                <rect key="frame" x="0.0" y="104" width="322" height="31"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                                 <constraints>
@@ -91,13 +91,39 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5DW-Oo-iRm">
+                                <rect key="frame" x="20" y="143" width="137" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Clear Selected">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="clearSelectedButtonTouchUpInside:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="OyU-T8-nvh"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7t9-ye-HPo">
+                                <rect key="frame" x="165" y="143" width="137" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Add Contacts">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="addContactsButtonTouchUpInside:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="YlX-CF-0gM"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="8rX-BI-7hI" firstAttribute="top" relation="lessThanOrEqual" secondItem="gVn-GW-f9z" secondAttribute="bottom" constant="433" id="Daz-nP-CV8"/>
+                            <constraint firstItem="7t9-ye-HPo" firstAttribute="top" secondItem="gVn-GW-f9z" secondAttribute="bottom" constant="8" id="1id-Hq-URW"/>
+                            <constraint firstItem="gVn-GW-f9z" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="7mJ-0V-NnG"/>
+                            <constraint firstItem="5DW-Oo-iRm" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" constant="20" id="8PC-xg-VtW"/>
+                            <constraint firstItem="7t9-ye-HPo" firstAttribute="leading" secondItem="5DW-Oo-iRm" secondAttribute="trailing" constant="8" id="Icf-RP-gBr"/>
+                            <constraint firstItem="5DW-Oo-iRm" firstAttribute="width" secondItem="7t9-ye-HPo" secondAttribute="width" id="MVX-xi-h72"/>
+                            <constraint firstAttribute="trailing" secondItem="gVn-GW-f9z" secondAttribute="trailing" id="WZN-GZ-kBf"/>
                             <constraint firstItem="gVn-GW-f9z" firstAttribute="top" secondItem="VDA-XU-QaJ" secondAttribute="bottom" constant="84" id="Xl9-hb-jrR"/>
-                            <constraint firstItem="gVn-GW-f9z" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="a7I-Ol-8O0"/>
-                            <constraint firstAttribute="trailing" secondItem="gVn-GW-f9z" secondAttribute="trailing" id="x0J-Ve-m6r"/>
+                            <constraint firstItem="5DW-Oo-iRm" firstAttribute="top" secondItem="gVn-GW-f9z" secondAttribute="bottom" constant="8" id="p5K-M5-IQY"/>
+                            <constraint firstAttribute="trailing" secondItem="7t9-ye-HPo" secondAttribute="trailing" constant="20" id="vRw-cs-uDf"/>
+                            <constraint firstItem="7t9-ye-HPo" firstAttribute="leading" secondItem="5DW-Oo-iRm" secondAttribute="trailing" constant="8" id="z87-Lg-3GE"/>
                         </constraints>
                     </view>
                     <connections>

--- a/Sample/MBContactPicker/ViewController.m
+++ b/Sample/MBContactPicker/ViewController.m
@@ -13,12 +13,30 @@
 @interface ViewController () <MBContactPickerDataSource, MBContactPickerDelegate>
 
 @property (nonatomic) NSArray *contacts;
+@property (nonatomic) NSArray *selectedContacts;
 @property (weak, nonatomic) IBOutlet MBContactPicker *contactPickerView;
 @property (nonatomic, weak) IBOutlet NSLayoutConstraint *contactPickerViewHeightConstraint;
 
 @end
 
 @implementation ViewController
+
+- (IBAction)clearSelectedButtonTouchUpInside:(id)sender
+{
+    self.selectedContacts = @[];
+    [self.contactPickerView reloadData];
+}
+- (IBAction)addContactsButtonTouchUpInside:(id)sender
+{
+    self.selectedContacts = @[
+                              self.contacts[0],
+                              self.contacts[1],
+                              self.contacts[2],
+                              self.contacts[3]
+                              ];
+    
+    [self.contactPickerView reloadData];
+}
 
 - (void)viewDidLoad
 {
@@ -29,7 +47,6 @@
                        @{@"Name":@"Matt Bowman", @"Title":@"Software Developer"},
                        @{@"Name":@"Matt Hupman", @"Title":@"Software Developer"},
                        @{@"Name":@"Erica Stein", @"Title":@"Creative"},
-                       @{@"Name":@"Bing Ding", @"Title":@"Creative"},
                        @{@"Name":@"Erin Pfiffner", @"Title":@"Creative"},
                        @{@"Name":@"Ben McGinnis", @"Title":@"Project Manager"},
                        @{@"Name":@"Lenny Pham", @"Title":@"Product Manager"},
@@ -48,7 +65,7 @@
         [contacts addObject:model];
     }
     self.contacts = contacts;
-    
+
     self.contactPickerView.delegate = self;
     self.contactPickerView.datasource = self;
 }
@@ -62,7 +79,7 @@
 
 - (NSArray *)selectedContactModelsForContactPicker:(MBContactPicker*)contactPickerView
 {
-    return @[];
+    return self.selectedContacts;
 }
 
 #pragma mark - MBContactPickerDelegate


### PR DESCRIPTION
Fixes #35 
- Change the willChangeContentSizeFrom:to: to not include the from value since it is invalid on data reloads or programmatic removal or addition of selected contacts
- Remove last content size logic from flow layout. If we want to be smart about when we invoke ‘willChangeContentSizeTo:’, we’ll need to find a better way to track content size changes
- This change removes the filtration of content size changes so that all changes are propagated, including ones that don’t cause a height change
- Update the sample application to include a button for clearing contacts and adding a group of selected contacts
