### PR TITLE
Make MBContactPickerModelProtocol properties read-only, ...

### DIFF
--- a/MBContactPicker/MBContactModel.h
+++ b/MBContactPicker/MBContactModel.h
@@ -12,12 +12,12 @@
 
 @required
 
-@property (nonatomic, copy) NSString *contactTitle;
+@property (readonly, nonatomic, copy) NSString *contactTitle;
 
 @optional
 
-@property (nonatomic, copy) NSString *contactSubtitle;
-@property (nonatomic) UIImage *contactImage;
+@property (readonly, nonatomic, copy) NSString *contactSubtitle;
+@property (readonly, nonatomic) UIImage *contactImage;
 
 @end
 


### PR DESCRIPTION
... since that is all that the picker implementation requires, and this avoids implementers having to either provide setters, or to ignore the Xcode warnings about them not being auto-generated from the protocol declaration.
