### PR TITLE
Make MBContactPickerModelProtocol properties read-only.

### DIFF
--- a/MBContactPicker/MBContactModel.h
+++ b/MBContactPicker/MBContactModel.h
@@ -12,12 +12,12 @@
 
 @required
 
-@property (nonatomic, copy) NSString *contactTitle;
+@property (readonly, nonatomic, copy) NSString *contactTitle;
 
 @optional
 
-@property (nonatomic, copy) NSString *contactSubtitle;
-@property (nonatomic) UIImage *contactImage;
+@property (readonly, nonatomic, copy) NSString *contactSubtitle;
+@property (readonly, nonatomic) UIImage *contactImage;
 
 @end
 


### PR DESCRIPTION
The properties defined in the `MBContactPickerModelProtocol` were defined as read-write, but the picker implementation only needs to read them. Marking them explicitly read-only saves implementors having to
either provide setters (which may simply discard the attempt to change the value), or ignore the Xcode warnings about the setters not being auto-generated.
