### PR TITLE
Add logic to recalculate item size when the width of the MBContactCollec...

### DIFF
--- a/MBContactPicker/MBContactCollectionView.m
+++ b/MBContactPicker/MBContactCollectionView.m
@@ -97,8 +97,8 @@ typedef NS_ENUM(NSInteger, ContactCollectionViewSection) {
     // * Technique taken from http://stackoverflow.com/a/13656570
     //
     // -[UICollectionViewLayout invalidateLayout] causes the layout to recalculate the layout of the cells, but it doesn't cause the
-    // size of the cells to be requeried via `collectionView:layout:sizeForItemAtIndexPath:`.  `performBatchUpdates:completion:`, however
-    // causes both an `invalidateLayout` and a the cell sizes to be requeried, which is exactly what we want.
+    // size of the cells to be requeried via `collectionView:layout:sizeForItemAtIndexPath:`.  `performBatchUpdates:completion:`,
+    // however, causes both an `invalidateLayout` and a the cell sizes to be requeried, which is exactly what we want.
     [self performBatchUpdates:nil completion:nil];
 }
 


### PR DESCRIPTION
...tionView changes since the size of the contact cells should be "greedy", taking up as much horizontal space as is available if they are currently truncated.

Potential fix for #55 

cc @brunchboy @MattCBowman
