### PR TITLE
Custom filtering and adding of tags not in list

### DIFF
--- a/MBContactPicker/MBContactCollectionView.h
+++ b/MBContactPicker/MBContactCollectionView.h
@@ -20,6 +20,7 @@
 
 - (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView willChangeContentSizeTo:(CGSize)newSize;
 - (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView entryTextDidChange:(NSString*)text;
+- (void)contactcollectionView:(MBContactCollectionView*)contactCollectionView didEnterCustomContact:(NSString*)text;
 - (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView didSelectContact:(id<MBContactPickerModelProtocol>)model;
 - (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView didAddContact:(id<MBContactPickerModelProtocol>)model;
 - (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView didRemoveContact:(id<MBContactPickerModelProtocol>)model;

--- a/MBContactPicker/MBContactCollectionView.m
+++ b/MBContactPicker/MBContactCollectionView.m
@@ -92,6 +92,12 @@ typedef NS_ENUM(NSInteger, ContactCollectionViewSection) {
     }
 }
 
+- (void) reloadData
+{
+    [super reloadData];
+    [self forceRelayout];
+}
+
 - (void)forceRelayout
 {
     // Use the flow layout call chain to relayout. This is also called by the performBatchUpdates call,

--- a/MBContactPicker/MBContactPicker.h
+++ b/MBContactPicker/MBContactPicker.h
@@ -31,6 +31,7 @@
 - (void)contactPicker:(MBContactPicker*)contactPicker didUpdateContentHeightTo:(CGFloat)newHeight;
 - (void)didShowFilteredContactsForContactPicker:(MBContactPicker*)contactPicker;
 - (void)didHideFilteredContactsForContactPicker:(MBContactPicker*)contactPicker;
+- (NSPredicate*) customFilterPredicate:(NSString*)searchString;
 
 @end
 
@@ -50,5 +51,5 @@
 @property (nonatomic) BOOL showPrompt;
 
 - (void)reloadData;
-
+- (void)addToSelectedContacts:(id<MBContactPickerModelProtocol>)model;
 @end

--- a/MBContactPicker/MBContactPicker.m
+++ b/MBContactPicker/MBContactPicker.m
@@ -300,7 +300,11 @@ CGFloat const kAnimationSpeed = .25;
         [self showSearchTableView];
         NSString *searchString = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
         NSPredicate *predicate;
-        if (self.allowsCompletionOfSelectedContacts) {
+        
+        if ([self.delegate respondsToSelector:@selector(customFilterPredicate:)])
+        {
+            predicate = [self.delegate customFilterPredicate:searchString];
+        } else if (self.allowsCompletionOfSelectedContacts) {
             predicate = [NSPredicate predicateWithFormat:@"contactTitle contains[cd] %@", searchString];
         } else {
             predicate = [NSPredicate predicateWithFormat:@"contactTitle contains[cd] %@ && !SELF IN %@", searchString, self.contactCollectionView.selectedContacts];
@@ -334,6 +338,22 @@ CGFloat const kAnimationSpeed = .25;
     }
 }
 
+- (void) contactcollectionView:(MBContactCollectionView *)contactCollectionView didEnterCustomContact:(NSString *)text
+{
+    if ([self.delegate respondsToSelector:@selector(contactcollectionView:didEnterCustomContact:)])
+    {
+        [self.delegate contactcollectionView:contactCollectionView didEnterCustomContact:text];
+        [self hideSearchTableView];
+
+    }
+}
+
+- (void)addToSelectedContacts:(id<MBContactPickerModelProtocol>)model
+{
+    [self.contactCollectionView addToSelectedContacts:model withCompletion:^{
+        [self becomeFirstResponder];
+    }];
+}
 #pragma mark - UIResponder
 
 - (BOOL)canBecomeFirstResponder

--- a/MBContactPicker/MBContactPicker.m
+++ b/MBContactPicker/MBContactPicker.m
@@ -154,10 +154,7 @@ CGFloat const kAnimationSpeed = .25;
     self.contacts = [self.datasource contactModelsForContactPicker:self];
     
     [self.contactCollectionView reloadData];
-    [self.contactCollectionView performBatchUpdates:^{
-    } completion:^(BOOL finished) {
-        [self.contactCollectionView scrollToEntryAnimated:NO onComplete:nil];
-    }];
+    [self.contactCollectionView scrollToEntryAnimated:NO onComplete:nil];
 }
 
 #pragma mark - Properties

--- a/Sample/MBContactPicker/ViewController.m
+++ b/Sample/MBContactPicker/ViewController.m
@@ -148,6 +148,25 @@
     }];
 }
 
+// This delegate method is invoked when the user types a contact that is not in the original
+// list provided to the contact picker.  Specifically this is triggered when the user presses
+// the 'return' key on the keyboard.
+- (void) contactcollectionView:(MBContactCollectionView *)contactCollectionView didEnterCustomContact:(NSString *)text
+{
+    MBContactModel *model = [[MBContactModel alloc] init];
+    model.contactTitle = text;
+    [self.contactPickerView addToSelectedContacts:model];
+}
+
+// This delegate method allows custom filtering by providing a predicate that filters
+// MBContactModel or a custom subclass that you have created. If this is not declared
+// then the default filtering implementation is used.
+- (NSPredicate*) customFilterPredicate:(NSString *)searchString
+{
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"contactTitle BEGINSWITH[cd] %@", searchString];
+    return predicate;
+}
+
 - (IBAction)takeFirstResponder:(id)sender
 {
     [self.contactPickerView becomeFirstResponder];


### PR DESCRIPTION
Added mechanism to add a contact that is not in the list provided to the contact picker.  Added delegate method to allow defining a custom predicate filter. Updated example view controller. Stability fixes related to crash with dealloc while UICollectionView is being updated.