### PR TITLE
Use a simpler method of invalidating our layout.  This handles resizing ...

### DIFF
--- a/MBContactPicker/MBContactCollectionView.m
+++ b/MBContactPicker/MBContactCollectionView.m
@@ -68,38 +68,16 @@ typedef NS_ENUM(NSInteger, ContactCollectionViewSection) {
 
 - (void)setFrame:(CGRect)frame
 {
-    CGFloat origWidth = self.frame.size.width;
+    [self.collectionViewLayout invalidateLayout];
     
     [super setFrame:frame];
-    
-    [self handleWidthChangeFrom:origWidth to:frame.size.width];
 }
 
 - (void)setBounds:(CGRect)bounds
 {
-    CGFloat origWidth = self.bounds.size.width;
+    [self.collectionViewLayout invalidateLayout];
     
     [super setBounds:bounds];
-    
-    [self handleWidthChangeFrom:origWidth to:bounds.size.width];
-}
-
-- (void)handleWidthChangeFrom:(CGFloat)oldWidth to:(CGFloat)newWidth
-{
-    if (oldWidth != newWidth)
-    {
-        [self forceRelayout];
-    }
-}
-
-- (void)forceRelayout
-{
-    // * Technique taken from http://stackoverflow.com/a/13656570
-    //
-    // -[UICollectionViewLayout invalidateLayout] causes the layout to recalculate the layout of the cells, but it doesn't cause the
-    // size of the cells to be requeried via `collectionView:layout:sizeForItemAtIndexPath:`.  `performBatchUpdates:completion:`,
-    // however, causes both an `invalidateLayout` and a the cell sizes to be requeried, which is exactly what we want.
-    [self performBatchUpdates:nil completion:nil];
 }
 
 - (void)setup


### PR DESCRIPTION
...cells due to any size change (for example, on device rotation).  Potential fix for #66.  @lttldrgn Would you mind checking this out?
