### PR TITLE
Allow for setting the font via UIAppearance properties.

### DIFF
--- a/MBContactPicker/MBContactCollectionViewContactCell.h
+++ b/MBContactPicker/MBContactCollectionViewContactCell.h
@@ -13,6 +13,7 @@
 
 @property (nonatomic, strong) id<MBContactPickerModelProtocol> model;
 @property (nonatomic) BOOL focused;
+@property (nonatomic, strong) UIFont *font UI_APPEARANCE_SELECTOR;
 
 - (CGFloat)widthForCellWithContact:(id<MBContactPickerModelProtocol>)model;
 

--- a/MBContactPicker/MBContactCollectionViewContactCell.m
+++ b/MBContactPicker/MBContactCollectionViewContactCell.m
@@ -45,6 +45,11 @@
     [self addSubview:contactLabel];
     contactLabel.textColor = [UIColor blueColor];
     contactLabel.textAlignment = NSTextAlignmentCenter;
+    UIFont *font = [[self.class appearance] font];
+    if (font)
+    {
+        contactLabel.font = font;
+    }
     [contactLabel setTranslatesAutoresizingMaskIntoConstraints:NO];
     self.contactTitleLabel = contactLabel;
 

--- a/MBContactPicker/MBContactCollectionViewEntryCell.h
+++ b/MBContactPicker/MBContactCollectionViewEntryCell.h
@@ -19,6 +19,7 @@
 @property (nonatomic, weak) id<UITextFieldDelegateImproved> delegate;
 @property (nonatomic, copy) NSString *text;
 @property (nonatomic) BOOL enabled;
+@property (nonatomic, strong) UIFont *font UI_APPEARANCE_SELECTOR;
 
 - (void)setFocus;
 - (void)removeFocus;

--- a/MBContactPicker/MBContactCollectionViewEntryCell.m
+++ b/MBContactPicker/MBContactCollectionViewEntryCell.m
@@ -50,6 +50,11 @@
     textField.delegate = self.delegate;
     textField.text = @" ";
     textField.autocorrectionType = UITextAutocorrectionTypeNo;
+    UIFont *font = [[self.class appearance] font];
+    if (font)
+    {
+        textField.font = font;
+    }
 #ifdef DEBUG_BORDERS
     self.layer.borderColor = [UIColor orangeColor].CGColor;
     self.layer.borderWidth = 1.0;

--- a/MBContactPicker/MBContactCollectionViewPromptCell.h
+++ b/MBContactPicker/MBContactCollectionViewPromptCell.h
@@ -12,6 +12,7 @@
 
 @property (nonatomic, copy) NSString *prompt;
 @property (nonatomic) UIEdgeInsets insets;
+@property (nonatomic, strong) UIFont *font UI_APPEARANCE_SELECTOR;
 
 + (CGFloat)widthWithPrompt:(NSString *)prompt;
 

--- a/MBContactPicker/MBContactCollectionViewPromptCell.m
+++ b/MBContactPicker/MBContactCollectionViewPromptCell.m
@@ -73,6 +73,11 @@
     label.textAlignment = NSTextAlignmentCenter;
     label.text = self.prompt;
     label.textColor = [UIColor blackColor];
+    UIFont *font = [[self.class appearance] font];
+    if (font)
+    {
+        label.font = font;
+    }
     self.promptLabel = label;
 }
 

--- a/MBContactPicker/MBContactPicker.h
+++ b/MBContactPicker/MBContactPicker.h
@@ -48,6 +48,7 @@
 @property (nonatomic) BOOL allowsCompletionOfSelectedContacts;
 @property (nonatomic) BOOL enabled;
 @property (nonatomic) BOOL showPrompt;
+@property (nonatomic, strong) UIFont *font UI_APPEARANCE_SELECTOR;
 
 - (void)reloadData;
 

--- a/MBContactPicker/MBContactPicker.m
+++ b/MBContactPicker/MBContactPicker.m
@@ -235,6 +235,11 @@ CGFloat const kAnimationSpeed = .25;
     id<MBContactPickerModelProtocol> model = (id<MBContactPickerModelProtocol>)self.filteredContacts[indexPath.row];
 
     cell.textLabel.text = model.contactTitle;
+    UIFont *font = [[self.class appearance] font];
+    if (font)
+    {
+        cell.textLabel.font = font;
+    }
 
     cell.detailTextLabel.text = nil;
     cell.imageView.image = nil;


### PR DESCRIPTION
For example:

```
    UIFont *font = [UIFont systemFontOfSize:12];
    [[MBContactPicker appearance] setFont:font];
    [[MBContactCollectionViewPromptCell appearance] setFont:font];
    [[MBContactCollectionViewEntryCell appearance] setFont:font];
    [[MBContactCollectionViewContactCell appearance] setFont:font];
```
