### PR TITLE
Fix confusion and typos with contactCollectionView:didEnterCustomContact:

### DIFF
--- a/MBContactPicker/MBContactCollectionView.h
+++ b/MBContactPicker/MBContactCollectionView.h
@@ -20,7 +20,7 @@
 
 - (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView willChangeContentSizeTo:(CGSize)newSize;
 - (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView entryTextDidChange:(NSString*)text;
-- (void)contactcollectionView:(MBContactCollectionView*)contactCollectionView didEnterCustomContact:(NSString*)text;
+- (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView didEnterCustomContact:(NSString*)text;
 - (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView didSelectContact:(id<MBContactPickerModelProtocol>)model;
 - (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView didAddContact:(id<MBContactPickerModelProtocol>)model;
 - (void)contactCollectionView:(MBContactCollectionView*)contactCollectionView didRemoveContact:(id<MBContactPickerModelProtocol>)model;

--- a/MBContactPicker/MBContactCollectionView.m
+++ b/MBContactPicker/MBContactCollectionView.m
@@ -556,13 +556,13 @@ typedef NS_ENUM(NSInteger, ContactCollectionViewSection) {
 
 - (BOOL)textFieldShouldReturn:(UITextField *)textField
 {
-    if ([self.contactDelegate respondsToSelector:@selector(contactcollectionView:didEnterCustomContact:)])
+    if ([self.contactDelegate respondsToSelector:@selector(contactCollectionView:didEnterCustomContact:)])
     {
         NSString *trimmedString = [textField.text stringByTrimmingCharactersInSet:
                                    [NSCharacterSet whitespaceCharacterSet]];
         if (trimmedString.length > 0)
         {
-            [self.contactDelegate contactcollectionView:self didEnterCustomContact:trimmedString];
+            [self.contactDelegate contactCollectionView:self didEnterCustomContact:trimmedString];
         }
     }
     return NO;

--- a/MBContactPicker/MBContactPicker.m
+++ b/MBContactPicker/MBContactPicker.m
@@ -342,11 +342,11 @@ CGFloat const kAnimationSpeed = .25;
     }
 }
 
-- (void) contactcollectionView:(MBContactCollectionView *)contactCollectionView didEnterCustomContact:(NSString *)text
+- (void) contactCollectionView:(MBContactCollectionView *)contactCollectionView didEnterCustomContact:(NSString *)text
 {
-    if ([self.delegate respondsToSelector:@selector(contactcollectionView:didEnterCustomContact:)])
+    if ([self.delegate respondsToSelector:@selector(contactPicker:didEnterCustomText:)])
     {
-        [self.delegate contactcollectionView:contactCollectionView didEnterCustomContact:text];
+        [self.delegate contactPicker:self didEnterCustomText:text];
         [self hideSearchTableView];
     }
 }

--- a/Sample/MBContactPicker/ViewController.m
+++ b/Sample/MBContactPicker/ViewController.m
@@ -152,7 +152,7 @@
 // This delegate method is invoked when the user types a contact that is not in the original
 // list provided to the contact picker.  Specifically this is triggered when the user presses
 // the 'return' key on the keyboard.
-- (void) contactcollectionView:(MBContactCollectionView *)contactCollectionView didEnterCustomContact:(NSString *)text
+- (void)contactPicker:(MBContactPicker *)contactPicker didEnterCustomText:(NSString *)text
 {
     MBContactModel *model = [[MBContactModel alloc] init];
     model.contactTitle = text;


### PR DESCRIPTION
I found that 'contactcollectionView:didEnterCustomContact:' on MBContactCollectionViewDelegate had a typo (the C in collection should be capitalized to be consistent with other delegate methods) and also that this method seems to have been confused by someone with contactPicker:didEnterCustomText: on the MBContactPickerDelegate, thus rendering the contactPicker:didEnterCustomText: completely unused, and an undocumented selector being called on MBContactPickerDelegate. 

I fixed the typo, and also, in the MBContactPicker, implement the contactCollectionView:didEnterCustomContact: by delegating to the documented contactPicker:didEnterCustomText: method on the MBContactPickerDelegate as should have been done. 

I also updated the example. 


WARNING: this could cause the code of someone who discovered the error and worked around it by adding a non-protocol method named contactcollectionView:didEnterCustomContact to their MBContactPickerDelegate to stop working. To fix this problem, they simply need to change the method name from 'contactcollectionView:didEnterCustomContact' to use the documented method contactPicker:didEnterCustomText: . 


