### PR TITLE
Fix conflict with UIView changes.

### DIFF
--- a/MBContactPicker/MBContactCollectionView.m
+++ b/MBContactPicker/MBContactCollectionView.m
@@ -404,7 +404,7 @@ typedef NS_ENUM(NSInteger, ContactCollectionViewSection) {
 {
     MBContactCollectionViewContactCell *cell = (MBContactCollectionViewContactCell *)[collectionView cellForItemAtIndexPath:indexPath];
     [self becomeFirstResponder];
-    cell.focused = YES;
+    cell.mbfocused = YES;
     
     if ([self.contactDelegate respondsToSelector:@selector(contactCollectionView:didSelectContact:)])
     {
@@ -420,7 +420,7 @@ typedef NS_ENUM(NSInteger, ContactCollectionViewSection) {
 - (void)collectionView:(UICollectionView *)collectionView didDeselectItemAtIndexPath:(NSIndexPath *)indexPath
 {
     MBContactCollectionViewContactCell *cell = (MBContactCollectionViewContactCell *)[collectionView cellForItemAtIndexPath:indexPath];
-    cell.focused = NO;
+    cell.mbfocused = NO;
 }
 
 #pragma mark - UICollectionViewDelegateContactFlowLayout
@@ -502,11 +502,11 @@ typedef NS_ENUM(NSInteger, ContactCollectionViewSection) {
         cell.model = self.selectedContacts[[self selectedContactIndexFromIndexPath:indexPath]];
         if ([self.indexPathOfSelectedCell isEqual:indexPath])
         {
-            cell.focused = YES;
+            cell.mbfocused = YES;
         }
         else
         {
-            cell.focused = NO;
+            cell.mbfocused = NO;
         }
         collectionCell = cell;
     }

--- a/MBContactPicker/MBContactCollectionViewContactCell.h
+++ b/MBContactPicker/MBContactCollectionViewContactCell.h
@@ -12,7 +12,7 @@
 @interface MBContactCollectionViewContactCell : UICollectionViewCell
 
 @property (nonatomic, strong) id<MBContactPickerModelProtocol> model;
-@property (nonatomic) BOOL focused;
+@property (nonatomic) BOOL mbfocused;
 @property (nonatomic, strong) UIFont *font UI_APPEARANCE_SELECTOR;
 
 - (CGFloat)widthForCellWithContact:(id<MBContactPickerModelProtocol>)model;

--- a/MBContactPicker/MBContactCollectionViewContactCell.m
+++ b/MBContactPicker/MBContactCollectionViewContactCell.m
@@ -84,7 +84,7 @@
 
 - (void)setFocused:(BOOL)focused
 {
-    _focused = focused;
+    _mbfocused = focused;
     
     if (focused)
     {


### PR DESCRIPTION
New UIKit “focused” property conflicted with local definition. Changed name of MBContactPicker property.

```objc
//
//  UIView.h
//  UIKit
//
//  Copyright (c) 2005-2014 Apple Inc. All rights reserved.
//
@property (readonly, nonatomic, getter=isFocused) BOOL focused NS_AVAILABLE_IOS(9_0);
```